### PR TITLE
Added safer, asynchronous calling of ObservationConsumers in Abstract…

### DIFF
--- a/flexiblepower.api/src/org/flexiblepower/observation/ext/AbstractObservationProvider.java
+++ b/flexiblepower.api/src/org/flexiblepower/observation/ext/AbstractObservationProvider.java
@@ -2,6 +2,8 @@ package org.flexiblepower.observation.ext;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.flexiblepower.observation.Observation;
@@ -18,8 +20,11 @@ import org.flexiblepower.observation.ObservationProvider;
  */
 public abstract class AbstractObservationProvider<T> implements ObservationProvider<T> {
 
-    private final Set<ObservationConsumer<? super T>> consumers = new CopyOnWriteArraySet<ObservationConsumer<? super T>>();
-    private final AtomicReference<Observation<? extends T>> lastObservation = new AtomicReference<Observation<? extends T>>(null);
+    private final Set<ObservationConsumer<? super T>> consumers =
+                                                                new CopyOnWriteArraySet<ObservationConsumer<? super T>>();
+    private final AtomicReference<Observation<? extends T>> lastObservation =
+                                                                            new AtomicReference<Observation<? extends T>>(null);
+    private final ExecutorService executorService = Executors.newFixedThreadPool(8);
 
     @Override
     public void subscribe(ObservationConsumer<? super T> consumer) {
@@ -42,10 +47,18 @@ public abstract class AbstractObservationProvider<T> implements ObservationProvi
      * @param observation
      *            The observation that will be sent.
      */
-    public void publish(Observation<? extends T> observation) {
+    public void publish(final Observation<? extends T> observation) {
         lastObservation.set(observation);
-        for (ObservationConsumer<? super T> consumer : consumers) {
-            consumer.consume(this, observation);
+        for (final ObservationConsumer<? super T> consumer : consumers) {
+            // Call each consumer in a separate thread through the ExecutorService so any exception or blocking
+            // behaviour in a consumer will not affect the main thread or calls to other consumers
+            final Runnable task = new Runnable() {
+                @Override
+                public void run() {
+                    consumer.consume(AbstractObservationProvider.this, observation);
+                }
+            };
+            executorService.submit(task);
         }
     }
 }


### PR DESCRIPTION
De publish methode van AbstractObservationProvider roept alle consumers aan in een for loopje, binnen dezelfde thread. Als één van deze consumers zich niet lekker gedraagt, bijv. een Exception treedt op in de consume methode, dan stopt de tread en worden andere consumers niet aangeroepen.

De wijziging zorgt ervoor dat alle consumers asynchroon dmv een Executor worden aangeroepen, zodat degene die publish aanroept zich niet druk hoeft te maken over wat er in die methode en in de ObservationConsumers gebeurt.